### PR TITLE
Add camera movement with WASD and Shift for level editor

### DIFF
--- a/LevelEditor/main.lua
+++ b/LevelEditor/main.lua
@@ -14,6 +14,8 @@ tiles = {
 	}
 }
 
+camera = {x = 0, y = 0}
+
 -- Create a map of all of the tiles by name
 tilesByName = {}
 -- Populate the map
@@ -21,13 +23,38 @@ for key, value in pairs(tiles) do
 	tilesByName[value.name] = value
 end
 
+love.window.setTitle("Level Editor")
 local width, height = love.graphics.getDimensions()
 
 -- Draw a single tile to the screen. Inverts y so that 0 is the bottom of the window.
--- Todo: Add camera x and y, and make this function adjust where tiles are drawn based on camera position.
 function drawTile(tile, x, y)
 	love.graphics.setColor(tile.color[1] / 255, tile.color[2] / 255, tile.color[3] / 255, 1)
-	love.graphics.rectangle("fill", x * 20, height - ((y + 1) * 20), 20, 20)
+	-- Account for camera position
+	local xPos = (x * 20) + camera.x
+	local yPos = (height - ((y + 1) * 20)) + camera.y
+	love.graphics.rectangle("fill", xPos, yPos, 20, 20)
+end
+
+function love.update()
+	-- Set default move speed
+	local diff = 4
+	-- If left shift is pressed, move faster
+	if love.keyboard.isDown("lshift") then
+		diff = 10
+	end
+	-- Handle WASD for camera movement
+	if love.keyboard.isDown("w") then
+		camera.y = camera.y + diff
+	end
+	if love.keyboard.isDown("s") then
+		camera.y = camera.y - diff
+	end
+	if love.keyboard.isDown("a") then
+		camera.x = camera.x + diff
+	end
+	if love.keyboard.isDown("d") then
+		camera.x = camera.x - diff
+	end
 end
 
 function love.draw()


### PR DESCRIPTION
Simple solution for being able to pan around to see different parts of the level you're editing. Currently actual editing is not possible, but will be added in a future (probably the next) update.