### PR TITLE
Allow setting size of level, increase window size

### DIFF
--- a/LevelEditor/camera.lua
+++ b/LevelEditor/camera.lua
@@ -3,10 +3,10 @@ Camera = {x = 0, y = 0}
 -- Call periodically to allow camera panning, call in love.update
 function Camera.update()
     -- Set default move speed
-	local diff = 4
+	local diff = 8
 	-- If left shift is pressed, move faster
 	if love.keyboard.isDown("lshift") then
-		diff = 10
+		diff = 20
 	end
 	-- Handle WASD for camera movement
 	if love.keyboard.isDown("w") then

--- a/LevelEditor/main.lua
+++ b/LevelEditor/main.lua
@@ -5,10 +5,19 @@ require("camera")
 -- Initialize everything
 local selectedTile = Tile.byName["wall"]
 love.window.setTitle("Level Editor")
+love.window.setMode(1200, 800)
 local mousePressed = false
-local width, height = love.graphics.getDimensions()
-local tileWidth, tileHeight = width / TileSize, height / TileSize
-Screen.init(tileWidth, tileHeight)
+local tileWidth, tileHeight
+
+function love.load(arg)
+	if #arg < 2 then
+		local width, height = love.graphics.getDimensions()
+		tileWidth, tileHeight = width / TileSize, height / TileSize
+	else
+		tileWidth, tileHeight = tonumber(arg[1]), tonumber(arg[2])
+	end
+	Screen.init(tileWidth, tileHeight)
+end
 
 function love.mousepressed(x, y, button, istouch, presses)
 	-- Todo: Handle mouse presses to draw tiles
@@ -16,6 +25,7 @@ function love.mousepressed(x, y, button, istouch, presses)
 		return
 	end
 	x, y = Screen.getTilePosition(x, y)
+	print(x.." "..y)
 	Screen.setTile(x, y, selectedTile)
 end
 

--- a/LevelEditor/screen.lua
+++ b/LevelEditor/screen.lua
@@ -35,7 +35,7 @@ end
 
 -- Get the screen pixel position from a tile position
 function Screen.getScreenPosition(x, y)
-    return (x * TileSize) + Camera.x, (height - ((y + 1) * TileSize)) + Camera.y
+    return (x * TileSize) + Camera.x, (Screen.height * TileSize - ((y + 1) * TileSize)) + Camera.y
 end
 
 -- Set a tile on the screen


### PR DESCRIPTION
Solves using command line arguments to specify a size for the level, also increases the window size for the level editor because it was far too small. Due to increasing the window size, I also doubled the speed at which the camera pans when using WASD, and also doubled the speed for when shift is held.